### PR TITLE
Avoid implicit failure of omitHeaders + few other changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ yarn add express-filestack
 Set your Filestack [upload URL](https://www.filestack.com/docs/api/file/#store) as an environment variable.
 
 ```sh
-FILESTACK_UPLOAD_URL='https://www.filestackapi.com/api/store/S3?key=4kBkTCq6QTqjkcprFyUN4c'`
+FILESTACK_UPLOAD_URL='https://www.filestackapi.com/api/store/S3?key=4kBkTCq6QTqjkcprFyUN4c'
 ```
 
-On completion the middleware will attach a `filestack` key to the express response object. It can be accessed as `res.filestack`. The key will contain a strigified JSON object if the upload is succcessful.
+On completion the middleware will attach a `filestack` key to the express response object. It can be accessed as `res.filestack`. The key will contain a stringified JSON object if the upload is succcessful.
 
 **Note: For cases when the API key is wrong, `res.filestack` will contain a response string and not stringified JSON.**
 
@@ -46,7 +46,7 @@ app.post('/uploads', filestack, (req, res) => {
 
     res.json({ data })
   } catch (err) {
-    // An uncsuccessful response string as a response
+    // An unsuccessful response string as a response
     // Use an error middleware here or return the response from Filestack
     res.json({ error: res.filestack })
   }

--- a/index.js
+++ b/index.js
@@ -4,30 +4,32 @@ const omit = require('lodash.omit')
 
 const debug = require('debug')('express-filestack')
 
+// The upload won't work without www in the URL ¯\_(ツ)_/¯
+const FILESTACK_API_BASE_URL = 'https://www.filestackapi.com/api'
+
 /**
  * Express middleware to pipe multipart/form-data requests to Filestack API.
  *
  * @param {*} opts
  */
 module.exports = function (opts) {
-  let uploadUrl = process.env.FILESTACK_UPLOAD_URL
-
-  if (opts.uploadUrl) {
-    uploadUrl = opts.uploadUrl
-  }
+  const uploadUrl = opts.uploadUrl || process.env.FILESTACK_UPLOAD_URL
 
   if (opts.debug === true) {
     debug.enabled = true
   }
 
   return function (req, res, next) {
-    // The upload won't work without www in the URL ¯\_(ツ)_/¯
-    if (uploadUrl.indexOf('https://www.filestackapi.com/api') !== 0) {
-      throw new Error('Please use a valid Filestack upload url')
+    if (uploadUrl.indexOf(FILESTACK_API_BASE_URL) !== 0) {
+      throw new Error('Please supply a valid Filestack upload url')
     }
 
-    if (opts.omitHeaders && Array.isArray(opts.omitHeaders)) {
-      req.headers = omit(req.headers, opts.omitHeaders)
+    if (opts.omitHeaders) {
+      if (!Array.isArray(opts.omitHeaders)) {
+        throw new Error(`Expected "omitHeaders" to be an Array but recieved ${typeof omitHeaders}`)
+      } else {
+        req.headers = omit(req.headers, opts.omitHeaders)
+      }
     }
 
     const options = {


### PR DESCRIPTION
# Changes:
* If `omitHeaders` was not an array, but some other data type - the code would silently fail. I think it's entirely plausible that someone might only pass a single header value. Better to be explicit about the error.
* Simplified merge of `process.env.FILESTACK_UPLOAD_URL` and `opts.uploadUrl`

Future changes?
- Might also make sense to include a `Troubleshooting` section in the README with a basic checklist of things that could go wrong. For e.g have they included `www` in the url? etc.
- A callback incase of an error when streaming. 